### PR TITLE
Size control for photos

### DIFF
--- a/SimplePhotoApp/Controller/AlbumCollectionViewController.swift
+++ b/SimplePhotoApp/Controller/AlbumCollectionViewController.swift
@@ -12,10 +12,12 @@ private let photoSegueIdentifier = "toPhotoViewSegue"
 
 class AlbumCollectionViewController: UICollectionViewController {
     
+    //MARK:- Variables
     var albums = [Album]()
     
     let collectionViewSpacing: CGFloat = 20
 
+    //MARK:- View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -56,7 +58,7 @@ class AlbumCollectionViewController: UICollectionViewController {
     }
     
 
-    // MARK: UICollectionViewDataSource
+    // MARK:- UICollectionViewDataSource
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
 
@@ -82,7 +84,7 @@ class AlbumCollectionViewController: UICollectionViewController {
         return UICollectionViewCell()
     }
 
-    // MARK: UICollectionViewDelegate
+    // MARK:- UICollectionViewDelegate
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let album = albums[indexPath.item]
@@ -92,7 +94,10 @@ class AlbumCollectionViewController: UICollectionViewController {
 
 }
 
+// MARK:- Extensions
 extension AlbumCollectionViewController: UICollectionViewDelegateFlowLayout {
+    
+    // MARK:- UICollectionViewFlowLayout
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         

--- a/SimplePhotoApp/Controller/DetailViewController.swift
+++ b/SimplePhotoApp/Controller/DetailViewController.swift
@@ -9,17 +9,21 @@ import UIKit
 
 class DetailViewController: UIViewController {
 
+    //MARK:- IBOutlets
     @IBOutlet weak var detailViewTitleLabel: UILabel!
     @IBOutlet weak var detailViewImageView: UIImageView!
     
+    //MARK:- Variables
     var photo: Photo?
     
+    //MARK:- View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
         showPhoto()
     }
     
+    //MARK:- Photo functions
     //Show photo and title of the photo object
     private func showPhoto() {
         guard let photo = photo else {

--- a/SimplePhotoApp/Controller/PhotoCollectionViewController.swift
+++ b/SimplePhotoApp/Controller/PhotoCollectionViewController.swift
@@ -15,15 +15,51 @@ class PhotoCollectionViewController: UICollectionViewController {
     //MARK:- Class Properties
     var photos = [Photo]()
     
+    /// The photoZoomValue is equivalent to the numbers of images that are displayed in a row
+    private var photoZoomValue: CGFloat = 2
+    
     //MARK: View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
         //The title of the navigationItem is set in the prepare(for segue) function in the previous AlbumCollectionViewController
         
+        //Add UIStepper for photo size control
+        addStepperToView()
+        
     }
     
-    // MARK:- UIStepper functions
+    // MARK:- UIStepper
+    
+    @objc func sizeStepperValueChanged(sender: UIStepper) {
+
+        // revert the value of the stepper, otherwise it would feel less intuitive when somebody taps plus and the images get smaller
+        switch sender.value {
+        case 1:
+            photoZoomValue = 4
+        case 2:
+            photoZoomValue = 3
+        case 3:
+            photoZoomValue = 2
+        case 4:
+            photoZoomValue = 1
+        default:
+            photoZoomValue = 2
+        }
+        
+        // inform the collectionView to update the size of its cells
+        collectionView.performBatchUpdates(nil, completion: nil)
+    }
+    
+    ///Add UIStepper to change the size of the displayed photos
+    private func addStepperToView() {
+        
+        self.view.addSubview(sizeStepper)
+        NSLayoutConstraint.activate([
+            sizeStepper.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -10),
+            sizeStepper.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -30)
+        ])
+    }
     
     // MARK:- Navigation
     
@@ -72,7 +108,16 @@ class PhotoCollectionViewController: UICollectionViewController {
     
     // MARK:- UI Initialization
     
-    //UIStepper
+    let sizeStepper: UIStepper = {
+        let stepper = UIStepper()
+        stepper.translatesAutoresizingMaskIntoConstraints = false
+        stepper.minimumValue = 1
+        stepper.maximumValue = 4
+        stepper.value = 3
+        stepper.addTarget(self, action: #selector(sizeStepperValueChanged(sender:)), for: .valueChanged)
+        
+        return stepper
+    }()
 }
 
 //MARK:- Extension
@@ -84,8 +129,12 @@ extension PhotoCollectionViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
         //The default view is a photo that is half the screens width, with a spacing of 1 between cells and lines
-        let halfScreenWidth = collectionView.frame.width/2-1
-        let size = CGSize(width: halfScreenWidth, height: halfScreenWidth)
+        //The images are always square
+        
+        let spacing = photoZoomValue-1
+        
+        let width = (collectionView.frame.width-spacing)/photoZoomValue
+        let size = CGSize(width: width, height: width)
         
         return size
     }

--- a/SimplePhotoApp/Controller/PhotoCollectionViewController.swift
+++ b/SimplePhotoApp/Controller/PhotoCollectionViewController.swift
@@ -12,8 +12,10 @@ private let toDetailViewSegueIdentifier = "toDetailViewSegue"
 
 class PhotoCollectionViewController: UICollectionViewController {
 
+    //MARK:- Class Properties
     var photos = [Photo]()
     
+    //MARK: View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -21,7 +23,9 @@ class PhotoCollectionViewController: UICollectionViewController {
         
     }
     
-    // MARK: - Navigation
+    // MARK:- UIStepper functions
+    
+    // MARK:- Navigation
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         
@@ -33,7 +37,7 @@ class PhotoCollectionViewController: UICollectionViewController {
         }
     }
 
-    // MARK: UICollectionViewDataSource
+    // MARK:- UICollectionViewDataSource
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
 
@@ -58,7 +62,7 @@ class PhotoCollectionViewController: UICollectionViewController {
         return UICollectionViewCell()
     }
 
-    // MARK: UICollectionViewDelegate
+    // MARK:- UICollectionViewDelegate
     
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let photo = photos[indexPath.item]
@@ -66,11 +70,16 @@ class PhotoCollectionViewController: UICollectionViewController {
         performSegue(withIdentifier: toDetailViewSegueIdentifier, sender: photo)
     }
     
+    // MARK:- UI Initialization
+    
+    //UIStepper
 }
+
+//MARK:- Extension
 
 extension PhotoCollectionViewController: UICollectionViewDelegateFlowLayout {
     
-    //MARK: UICollectionViewDelegateFlowLayout
+    //MARK:- UICollectionViewDelegateFlowLayout
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         

--- a/SimplePhotoApp/Model/Network.swift
+++ b/SimplePhotoApp/Model/Network.swift
@@ -9,6 +9,8 @@ import Foundation
 
 class Network {
     
+    //MARK:- Album functions
+    
     /// This function fetches albums from a website for pseudo JSON data.
     ///
     /// - Parameter completionHandler: Asynchrounious callback.
@@ -53,6 +55,8 @@ class Network {
             }.resume()
         }
     }
+    
+    //MARK:- Photo functions
     
     /// This function fetches photos from a specified album within a website that presents pseudo JSON data.
     ///

--- a/SimplePhotoApp/View/Cells/AlbumCell.swift
+++ b/SimplePhotoApp/View/Cells/AlbumCell.swift
@@ -10,9 +10,11 @@ import SDWebImage
 
 class AlbumCell: UICollectionViewCell {
     
+    //MARK:- IBOutlets
     @IBOutlet weak var albumCellImageView: UIImageView!
     @IBOutlet weak var albumCellTitleLabel: UILabel!
     
+    //MARK:- Variables
     var album: Album? {
         didSet {
             if let album = album {
@@ -27,6 +29,7 @@ class AlbumCell: UICollectionViewCell {
         }
     }
     
+    //MARK:- Photo functions
     ///set the thumnail picture from the first photo of the current album
     func setThumbnailPhoto(photos: [Photo]) {
         if let photo = photos.first {
@@ -48,6 +51,7 @@ class AlbumCell: UICollectionViewCell {
         }
     }
     
+    //MARK:- Cell lifecycle
     override func awakeFromNib() {
         albumCellImageView.layer.cornerRadius = 8
     }

--- a/SimplePhotoApp/View/Cells/PhotoCell.swift
+++ b/SimplePhotoApp/View/Cells/PhotoCell.swift
@@ -9,8 +9,10 @@ import UIKit
 
 class PhotoCell: UICollectionViewCell {
     
+    //MARK:- IBOutlets
     @IBOutlet weak var photoCellImageView: UIImageView!
     
+    //MARK:- Variables
     ///Set the photo for it to be displayed in the cell
     var photo: Photo? {
         didSet {
@@ -22,6 +24,7 @@ class PhotoCell: UICollectionViewCell {
         }
     }
     
+    //MARK:- Cell Lifecycle
     override func prepareForReuse() {
         photoCellImageView.image = nil
     }


### PR DESCRIPTION
Change the size of the displayed photos after you select an album.
You can use an UIStepper on the lower right to zoom in and out, or use a natural pinch motion to show the images in the preferred way.

- Documentation added in 6 files
- Code for the size Control in PhotoCollectionViewController.swift